### PR TITLE
Simply source yaml properties

### DIFF
--- a/foresight_free/trip_fare/trip_fare_data_sources.yml
+++ b/foresight_free/trip_fare/trip_fare_data_sources.yml
@@ -10,9 +10,6 @@ sources:
       source_format: csv
       path: s3a://foresight-tutorial/trip_fare/trip_table.csv
       anon: true
-      infer_schema: true
-      header: true
       delimiter: ','
-      batch_schedule: -1d
       s3_endpoint_url: https://s3.us-west-2.amazonaws.com
 

--- a/foresight_free/trip_fare/trip_fare_prediction_1.ipynb
+++ b/foresight_free/trip_fare/trip_fare_prediction_1.ipynb
@@ -91,11 +91,8 @@
     "              source_format: csv\n",
     "              path: s3a://foresight-tutorial/trip_fare/trip_table.csv                 \n",
     "              anon: true                                                              \n",
-    "              infer_schema: true                                                      \n",
-    "              header: true                                                            \n",
     "              delimiter: ','                                                          \n",
     "              s3_endpoint_url: https://s3.us-west-2.amazonaws.com  \n",
-    "              batch_schedule: -1d\n",
     "              \n",
     "The S3 bucket or any other source (MySql, Kafka, etc.) if you wish to use, its credentials must be specified in the sources file."
    ]

--- a/foresight_free/trip_fare/trip_fare_prediction_2.ipynb
+++ b/foresight_free/trip_fare/trip_fare_prediction_2.ipynb
@@ -117,11 +117,8 @@
     "              source_format: csv\n",
     "              path: s3a://foresight-tutorial/trip_fare/<table_name>.csv         <<<<                \n",
     "              anon: true                                                              \n",
-    "              infer_schema: true                                                      \n",
-    "              header: true                                                            \n",
     "              delimiter: ','                                                          \n",
-    "              s3_endpoint_url: https://foresight-tutorial.s3.us-west-2.amazonaws.com  \n",
-    "              batch_schedule: -1d"
+    "              s3_endpoint_url: https://foresight-tutorial.s3.us-west-2.amazonaws.com  \n"
    ]
   },
   {

--- a/foresight_free/trip_fare/trip_fare_prediction_model_2/trip_fare_2_data_sources.yml
+++ b/foresight_free/trip_fare/trip_fare_prediction_model_2/trip_fare_2_data_sources.yml
@@ -9,10 +9,7 @@ sources:
       source_format: csv
       path: s3a://foresight-tutorial/trip_fare/hour_of_day_context.csv
       anon: true
-      infer_schema: true
-      header: true
       delimiter: ','
-      batch_schedule: -1d
       s3_endpoint_url: https://s3.us-west-2.amazonaws.com
 
   - name: holiday_weekend_context
@@ -22,10 +19,7 @@ sources:
       source_format: csv
       path: s3a://foresight-tutorial/trip_fare/holiday_weekend_context.csv
       anon: true
-      infer_schema: true
-      header: true
       delimiter: ','
-      batch_schedule: -1d
       s3_endpoint_url: https://s3.us-west-2.amazonaws.com
 
   - name: geo_area_context
@@ -35,8 +29,5 @@ sources:
       source_format: csv
       path: s3a://foresight-tutorial/trip_fare/geo_area_context.csv
       anon: true
-      infer_schema: true
-      header: true
       delimiter: ','
-      batch_schedule: -1d
       s3_endpoint_url: https://s3.us-west-2.amazonaws.com

--- a/foresight_licensed/trip_fare/trip_fare_data_sources.yml
+++ b/foresight_licensed/trip_fare/trip_fare_data_sources.yml
@@ -10,8 +10,5 @@ sources:
       source_format: csv
       path: s3a://foresight-tutorial/trip_fare/trip_table.csv
       anon: true
-      infer_schema: true
-      header: true
       delimiter: ','
-      batch_schedule: -1d
       s3_endpoint_url: https://s3.us-west-2.amazonaws.com

--- a/foresight_licensed/trip_fare/trip_fare_prediction_1.ipynb
+++ b/foresight_licensed/trip_fare/trip_fare_prediction_1.ipynb
@@ -91,11 +91,8 @@
     "              source_format: csv\n",
     "              path: s3a://foresight-tutorial/trip_fare/trip_table.csv                 \n",
     "              anon: true                                                              \n",
-    "              infer_schema: true                                                      \n",
-    "              header: true                                                            \n",
     "              delimiter: ','                                                          \n",
     "              s3_endpoint_url: https://s3.us-west-2.amazonaws.com  \n",
-    "              batch_schedule: -1d\n",
     "              \n",
     "The S3 bucket or any other source (MySql, Kafka, etc.) if you wish to use, its credentials must be specified in the sources file."
    ]

--- a/foresight_licensed/trip_fare/trip_fare_prediction_2.ipynb
+++ b/foresight_licensed/trip_fare/trip_fare_prediction_2.ipynb
@@ -118,11 +118,8 @@
     "              source_format: csv\n",
     "              path: s3a://foresight-tutorial/trip_fare/<table_name>.csv         <<<<                \n",
     "              anon: true                                                              \n",
-    "              infer_schema: true                                                      \n",
-    "              header: true                                                            \n",
     "              delimiter: ','                                                          \n",
-    "              s3_endpoint_url: https://foresight-tutorial.s3.us-west-2.amazonaws.com  \n",
-    "              batch_schedule: -1d"
+    "              s3_endpoint_url: https://foresight-tutorial.s3.us-west-2.amazonaws.com  \n"
    ]
   },
   {

--- a/foresight_licensed/trip_fare/trip_fare_prediction_3.ipynb
+++ b/foresight_licensed/trip_fare/trip_fare_prediction_3.ipynb
@@ -834,8 +834,6 @@
     "              source_format: csv\n",
     "              url: <kafka server>:9092                                              <<<\n",
     "              topic: tutorial_client_<xxxx_xxxxxx>_trip_table                       <<<\n",
-    "              offset: latest\n",
-    "              streaming_window: 2 seconds\n",
     "              preprocessor: com.aizen.preprocessors.DefaultCsvPreprocessor\n"
    ]
   },

--- a/foresight_licensed/trip_fare/trip_fare_prediction_model_2/trip_fare_2_data_sources.yml
+++ b/foresight_licensed/trip_fare/trip_fare_prediction_model_2/trip_fare_2_data_sources.yml
@@ -9,10 +9,7 @@ sources:
       source_format: csv
       path: s3a://foresight-tutorial/trip_fare/hour_of_day_context.csv
       anon: true
-      infer_schema: true
-      header: true
       delimiter: ','
-      batch_schedule: -1d
       s3_endpoint_url: https://s3.us-west-2.amazonaws.com
 
   - name: holiday_weekend_context
@@ -22,10 +19,7 @@ sources:
       source_format: csv
       path: s3a://foresight-tutorial/trip_fare/holiday_weekend_context.csv
       anon: true
-      infer_schema: true
-      header: true
       delimiter: ','
-      batch_schedule: -1d
       s3_endpoint_url: https://s3.us-west-2.amazonaws.com
 
   - name: geo_area_context
@@ -35,8 +29,5 @@ sources:
       source_format: csv
       path: s3a://foresight-tutorial/trip_fare/geo_area_context.csv
       anon: true
-      infer_schema: true
-      header: true
       delimiter: ','
-      batch_schedule: -1d
       s3_endpoint_url: https://s3.us-west-2.amazonaws.com

--- a/foresight_licensed/trip_fare/trip_fare_prediction_model_3/trip_fare_3_data_sources.yml
+++ b/foresight_licensed/trip_fare/trip_fare_prediction_model_3/trip_fare_3_data_sources.yml
@@ -2,10 +2,6 @@ version: 2
 
 sources:
   - name: kafka
-    quoting:
-      database: false
-      schema: false
-      identifier: false
     tables:
       - name: trip_events
         description: "Ride information for each trip"
@@ -14,7 +10,5 @@ sources:
           source_format: json
           url: <kafka server>:9092
           topic: tutorial_client_<xxxx_xxxxxx>_trip_table11
-          offset: latest
-          streaming_window: 2 seconds
           preprocessor: com.aizen.preprocessors.DefaultJsonPreprocessor
 


### PR DESCRIPTION
Simplify the source yaml definitions by removing the properties that most of the time use standard values and these will values will now be defaulted during runtime.